### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout-v21/main.xml
+++ b/app/src/main/res/layout-v21/main.xml
@@ -38,6 +38,7 @@
         android:imeActionLabel="@string/done"
         android:imeOptions="actionDone"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:singleLine="true"
         app:showVisualHash="true"
         app:visualHashHeight="45dip"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -39,6 +39,7 @@
         android:imeActionLabel="@string/done"
         android:imeOptions="actionDone"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:singleLine="true"
         app:showVisualHash="true"
         app:visualHashHeight="45dip"

--- a/app/src/main/res/layout/master_pw_verify.xml
+++ b/app/src/main/res/layout/master_pw_verify.xml
@@ -15,6 +15,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:hint="@string/dialog_verify_hint"
-        android:inputType="textPassword" />
+        android:inputType="textPassword"
+        android:importantForAccessibility="no" />
 
 </LinearLayout>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.